### PR TITLE
Firefox compatibility

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -35,8 +35,8 @@ let selectTab = (direction) => {
           toSelect = tabs[tabs.length - 1]
           break
       }
-      chrome.tabs.update(toSelect.id, {highlighted: true})
-      chrome.tabs.update(currentTab.id, {highlighted: false})
+      chrome.tabs.update(toSelect.id, {active: true})
+      // chrome.tabs.update(currentTab.id, {active: false})
     })
   })
 }
@@ -109,7 +109,7 @@ let handleAction = (action, request = {}) => {
   } else if (action === 'reopentab') {
     chrome.sessions.getRecentlyClosed({maxResults: 1}, function (sessions) {
       let closedTab = sessions[0]
-      chrome.sessions.restore(closedTab.sessionsId)
+      chrome.sessions.restore(closedTab.sessionId)
     })
   } else if (action === 'closetab') {
     chrome.tabs.query({currentWindow: true, active: true}, (tab) => {
@@ -185,7 +185,7 @@ let handleAction = (action, request = {}) => {
       }
       chrome.tabs.query(queryOption, function (tabs) {
         if (tabs.length > 0) {
-          chrome.tabs.update(tabs[0].id, {selected: true})
+          chrome.tabs.update(tabs[0].id, {active: true})
           chrome.windows.update(tabs[0].windowId, {focused: true})
         } else {
           createNewTab()

--- a/app/scripts/options.js
+++ b/app/scripts/options.js
@@ -75,7 +75,8 @@ app.controller('ShortkeysOptionsCtrl', ['$scope', function ($scope) {
   $scope.isBuiltIn = function (action) {
     for (let i = 0, len = $scope.actionOptions.length; i < len; i++) {
       if ($scope.actionOptions[i].value === action) {
-        return $scope.actionOptions[i].builtin || false
+        //builtin actions do not work in Firefox yet
+        return ($scope.actionOptions[i].builtin || false) && process.env.VENDOR !== 'firefox'
       }
     }
   }


### PR DESCRIPTION
Replaced tabs.update 'highlighted' and 'selected' options with 'active' option - this should work for chrome as well.
Removed message that informs about the builtin options in Firefox.

The clear downloads action does not seem to clear all historical downloads, only the ones in current session. It seems that something is broken in FF (https://bugzilla.mozilla.org/show_bug.cgi?id=1255507) . Let's try and re-test in FF 60.
