### PR TITLE
When search google, the new tab will be next to the current tab

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -167,7 +167,9 @@ let handleAction = (action, request = {}) => {
     }, function (selection) {
       if (selection[0]) {
         let query = encodeURIComponent(selection[0])
-        chrome.tabs.create({url: 'https://www.google.com/search?q=' + query})
+        chrome.tabs.query({currentWindow: true, active: true}, (tab) => {
+          chrome.tabs.create({url: 'https://www.google.com/search?q=' + query, index: tab.index + 1})
+        })
       }
     })
   } else if (action === 'movetableft') {

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -167,8 +167,8 @@ let handleAction = (action, request = {}) => {
     }, function (selection) {
       if (selection[0]) {
         let query = encodeURIComponent(selection[0])
-        chrome.tabs.query({currentWindow: true, active: true}, (tab) => {
-          chrome.tabs.create({url: 'https://www.google.com/search?q=' + query, index: tab.index + 1})
+        chrome.tabs.query({currentWindow: true, active: true}, (tabs) => {
+          chrome.tabs.create({url: 'https://www.google.com/search?q=' + query, index: tabs[0].index + 1})
         })
       }
     })


### PR DESCRIPTION
So, for lots of time I used the function "search google", I will just go back to the original tab after gathered the information that I need. As a result, it's a lot easier for me to open the new google tab at the position next to the original tab, instead of using the default setting which will open the new tab at the rightmost position.