### PR TITLE
Firefox style fixes

### DIFF
--- a/app/scripts/options.js
+++ b/app/scripts/options.js
@@ -273,10 +273,6 @@ app.controller('ShortkeysOptionsCtrl', ['$scope', function ($scope) {
   })
 }])
 
-try {
-  browser.runtime.getBrowserInfo().then((result) => {
-    if (result && result.name === 'Firefox') {
-      document.documentElement.classList.add('firefox')
-    }
-  })
-} catch (error) { }
+if (process.env.VENDOR === 'firefox') {
+  document.documentElement.classList.add('firefox')
+}

--- a/app/scripts/options.js
+++ b/app/scripts/options.js
@@ -273,7 +273,10 @@ app.controller('ShortkeysOptionsCtrl', ['$scope', function ($scope) {
   })
 }])
 
-if (browser) {
-  // Firefox fixes:
-  document.documentElement.classList.add('firefox')
-}
+try {
+  browser.runtime.getBrowserInfo().then((result) => {
+    if (result && result.name === 'Firefox') {
+      document.documentElement.classList.add('firefox')
+    }
+  })
+} catch (error) { }

--- a/app/scripts/options.js
+++ b/app/scripts/options.js
@@ -272,3 +272,9 @@ app.controller('ShortkeysOptionsCtrl', ['$scope', function ($scope) {
     $scope.$apply()
   })
 }])
+
+
+if (browser) {
+  // Firefox fixes:
+  document.documentElement.classList.add("firefox")
+}

--- a/app/scripts/options.js
+++ b/app/scripts/options.js
@@ -273,8 +273,7 @@ app.controller('ShortkeysOptionsCtrl', ['$scope', function ($scope) {
   })
 }])
 
-
 if (browser) {
   // Firefox fixes:
-  document.documentElement.classList.add("firefox")
+  document.documentElement.classList.add('firefox')
 }

--- a/app/styles/options.scss
+++ b/app/styles/options.scss
@@ -47,3 +47,16 @@ button {
   margin: 0px 1px 0px 0px;
   outline: none;
 }
+
+// Firefox fixes:
+:root.firefox body {
+  overflow-y: hidden;
+  background-color: transparent;
+}
+:root.firefox body > div {
+  width: 100%;
+}
+:root.firefox .nav-tabs > li.active > a {
+  background-color: transparent;
+  border-bottom-color: #f9f9fa;
+}

--- a/app/styles/options.scss
+++ b/app/styles/options.scss
@@ -52,6 +52,7 @@ button {
 :root.firefox body {
   overflow-y: hidden;
   background-color: transparent;
+  min-width: unset;
 }
 :root.firefox body > div {
   width: 100%;

--- a/package.json
+++ b/package.json
@@ -19,8 +19,7 @@
   },
   "standard": {
     "globals": [
-      "chrome",
-      "browser"
+      "chrome"
     ]
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
   },
   "standard": {
     "globals": [
-      "chrome"
+      "chrome",
+      "browser"
     ]
   },
   "devDependencies": {


### PR DESCRIPTION
The option menu in Firefox looks a bit wrong since it doesn't match the background color of the rest of the page. I think this pull request should fix that. Also sometimes when elements are expanded and collapsed quickly an extra vertical scrollbar will appear in the body of the option page. In Firefox the option page itself handles this so its better to just disable it in the addons option page.