### PR TITLE
Fix the need to reload tabs in order to use shortcuts

### DIFF
--- a/app/manifest.json
+++ b/app/manifest.json
@@ -155,7 +155,7 @@
         "vendor/mousetrap.min.js",
         "scripts/contentscript.js"
       ],
-      "run_at": "document_end",
+      "run_at": "document_start",
       "all_frames": true,
       "match_about_blank": true
     }

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -315,7 +315,7 @@ let handleAction = (action, request = {}) => {
                 file: "/vendor/mousetrap.min.js",
                 allFrames: true,
                 matchAboutBlank: true,
-                runAt: "document_end",
+                runAt: "document_start",
               }
               chrome.tabs.executeScript(tab.id, details, function () {
                 if (chrome.runtime.lastError) {

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -374,4 +374,3 @@ chrome.runtime.onInstalled.addListener(function (details) {
     handleAction('updateShortkeys', { inject: true })
   }
 })
-

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -290,6 +290,47 @@ let handleAction = (action, request = {}) => {
         chrome.tabs.create({url: decodeURI(openNode.url)})
       }
     })
+  } else if (action === "updateShortkeys") {
+    chrome.tabs.query({discarded: false}, (tabs) => {
+      for (let tab of tabs) {
+        if (request.inject) {
+          let hasLoadedContentScript = false
+
+          chrome.tabs.sendMessage(tab.id, {action: "update"}, function (response) {
+            if (chrome.runtime.lastError) {
+              return
+            }
+            if (response && response.handled !== undefined) {
+              hasLoadedContentScript = true
+            }
+          })
+
+          let timeout = 1000
+          if (request.timeout) {
+            timeout = request.timeout
+          }
+          setTimeout(function () {
+            if (!hasLoadedContentScript) {
+              let details = {
+                file: "/vendor/mousetrap.min.js",
+                allFrames: true,
+                matchAboutBlank: true,
+                runAt: "document_end",
+              }
+              chrome.tabs.executeScript(tab.id, details, function () {
+                if (chrome.runtime.lastError) {
+                  return
+                }
+                details.file = "/scripts/contentscript.js"
+                chrome.tabs.executeScript(tab.id, details)
+              })
+            }
+          }, timeout)
+        } else {
+          chrome.tabs.sendMessage(tab.id, {action: "update"})
+        }
+      }
+    })
   } else {
     return false
   }

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -360,3 +360,17 @@ chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
   }
   handleAction(action, request)
 })
+
+chrome.runtime.onInstalled.addListener(function (details) {
+  console.log(
+    "Extension install event:" +
+    "\nReason: " + details.reason +
+    "\nPrevious version" + details.previousVersion +
+    "\nid: " + details.id
+  )
+
+  if (details.reason && (details.reason === "update" || details.reason === "install")) {
+    console.log("Extension installed or updated. Checking if content scripts are loaded.")
+    handleAction("updateShortkeys", { inject: true })
+  }
+})

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -290,13 +290,13 @@ let handleAction = (action, request = {}) => {
         chrome.tabs.create({url: decodeURI(openNode.url)})
       }
     })
-  } else if (action === "updateShortkeys") {
+  } else if (action === 'updateShortkeys') {
     chrome.tabs.query({discarded: false}, (tabs) => {
       for (let tab of tabs) {
         if (request.inject) {
           let hasLoadedContentScript = false
 
-          chrome.tabs.sendMessage(tab.id, {action: "update"}, function (response) {
+          chrome.tabs.sendMessage(tab.id, {action: 'update'}, function (response) {
             if (chrome.runtime.lastError) {
               return
             }
@@ -312,22 +312,22 @@ let handleAction = (action, request = {}) => {
           setTimeout(function () {
             if (!hasLoadedContentScript) {
               let details = {
-                file: "/vendor/mousetrap.min.js",
+                file: '/vendor/mousetrap.min.js',
                 allFrames: true,
                 matchAboutBlank: true,
-                runAt: "document_start",
+                runAt: 'document_start'
               }
               chrome.tabs.executeScript(tab.id, details, function () {
                 if (chrome.runtime.lastError) {
                   return
                 }
-                details.file = "/scripts/contentscript.js"
+                details.file = '/scripts/contentscript.js'
                 chrome.tabs.executeScript(tab.id, details)
               })
             }
           }, timeout)
         } else {
-          chrome.tabs.sendMessage(tab.id, {action: "update"})
+          chrome.tabs.sendMessage(tab.id, {action: 'update'})
         }
       }
     })
@@ -363,14 +363,15 @@ chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
 
 chrome.runtime.onInstalled.addListener(function (details) {
   console.log(
-    "Extension install event:" +
-    "\nReason: " + details.reason +
-    "\nPrevious version" + details.previousVersion +
-    "\nid: " + details.id
+    'Extension install event:' +
+    '\nReason: ' + details.reason +
+    '\nPrevious version' + details.previousVersion +
+    '\nid: ' + details.id
   )
 
-  if (details.reason && (details.reason === "update" || details.reason === "install")) {
-    console.log("Extension installed or updated. Checking if content scripts are loaded.")
-    handleAction("updateShortkeys", { inject: true })
+  if (details.reason && (details.reason === 'update' || details.reason === 'install')) {
+    console.log('Extension installed or updated. Checking if content scripts are loaded.')
+    handleAction('updateShortkeys', { inject: true })
   }
 })
+

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -361,6 +361,7 @@ chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
   handleAction(action, request)
 })
 
+let hasInjectContentScript = false
 chrome.runtime.onInstalled.addListener(function (details) {
   console.log(
     'Extension install event:' +
@@ -371,6 +372,23 @@ chrome.runtime.onInstalled.addListener(function (details) {
 
   if (details.reason && (details.reason === 'update' || details.reason === 'install')) {
     console.log('Extension installed or updated. Checking if content scripts are loaded.')
-    handleAction('updateShortkeys', { inject: true })
+    if (!hasInjectContentScript) {
+      handleAction('updateShortkeys', { inject: true })
+      hasInjectContentScript = true
+    }
   }
 })
+
+let isBrowserStartup = false
+chrome.runtime.onStartup.addListener(function () {
+  console.log('Browser started.')
+  isBrowserStartup = true
+})
+
+setTimeout(function () {
+  if (!isBrowserStartup && !hasInjectContentScript) {
+    console.log('Extension enabled.')
+    handleAction('updateShortkeys', { inject: true })
+    hasInjectContentScript = true
+  }
+}, 1000)

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -387,7 +387,7 @@ chrome.runtime.onStartup.addListener(function () {
 
 setTimeout(function () {
   if (!isBrowserStartup && !hasInjectContentScript) {
-    console.log('Extension enabled.')
+    console.log('Extension enabled or browser started in incognito/private mode. Checking if content scripts are loaded.')
     handleAction('updateShortkeys', { inject: true })
     hasInjectContentScript = true
   }

--- a/app/scripts/contentscript.js
+++ b/app/scripts/contentscript.js
@@ -141,10 +141,6 @@ Shortkeys.getShortkeys = () => {
 }
 
 chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
-  if (sender.id !== chrome.runtime.id) {
-    // Prevent other extensions from interacting with this extension.
-    return
-  }
   let handled = true
   if (request.action === 'update') {
     Shortkeys.getShortkeys()

--- a/app/scripts/contentscript.js
+++ b/app/scripts/contentscript.js
@@ -3,6 +3,7 @@
 
 let Shortkeys = {}
 Shortkeys.keys = []
+Shortkeys.activeKeys = []
 
 /**
  * Helper function for fetching the full key shortcut config given a keyboard combo.
@@ -67,7 +68,19 @@ Shortkeys.activateKey = (keySetting) => {
     Shortkeys.doAction(keySetting)
     return false
   }
-  Mousetrap.bind(keySetting.key.toLowerCase(), action)
+  let keys = keySetting.key.toLowerCase()
+  Mousetrap.bind(keys, action)
+
+  return { keys: keys, action: action }
+}
+
+/**
+ * Deactivates an active key bind item.
+ *
+ * @param activeKey
+ */
+Shortkeys.deactivateKey = (activeKey) => {
+  Mousetrap.unbind(activeKey.keys, activeKey.action)
 }
 
 /**
@@ -106,13 +119,39 @@ Mousetrap.prototype.stopCallback = function (e, element, combo) {
 /**
  * Fetches the Shortkeys configuration object and wires up each configured shortcut.
  */
-chrome.runtime.sendMessage({action: 'getKeys', url: document.URL}, function (response) {
-  if (response) {
-    Shortkeys.keys = response
-    if (Shortkeys.keys.length > 0) {
-      Shortkeys.keys.forEach((key) => {
-        Shortkeys.activateKey(key)
-      })
+Shortkeys.getShortkeys = () => {
+  chrome.runtime.sendMessage({ action: 'getKeys', url: document.URL }, function (response) {
+    if (response) {
+      // Remove old keybindings:
+      if (Shortkeys.activeKeys.length > 0) {
+        Shortkeys.activeKeys.forEach((activeKey) => {
+          Shortkeys.deactivateKey(activeKey)
+        })
+      }
+      Shortkeys.activeKeys = []
+      // Activate new keybindings:
+      Shortkeys.keys = response
+      if (Shortkeys.keys.length > 0) {
+        Shortkeys.keys.forEach((key) => {
+          Shortkeys.activeKeys.push(Shortkeys.activateKey(key))
+        })
+      }
     }
+  })
+}
+
+chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
+  if (sender.id !== chrome.runtime.id) {
+    // Prevent other extensions from interacting with this extension.
+    return
   }
+  let handled = true
+  if (request.action === "update") {
+    Shortkeys.getShortkeys()
+  } else {
+    handled = false
+  }
+  sendResponse({ handled: handled })
 })
+
+Shortkeys.getShortkeys()

--- a/app/scripts/contentscript.js
+++ b/app/scripts/contentscript.js
@@ -80,7 +80,7 @@ Shortkeys.activateKey = (keySetting) => {
  * @param activeKey
  */
 Shortkeys.deactivateKey = (activeKey) => {
-  Mousetrap.unbind(activeKey.keys, activeKey.action)
+  Mousetrap.unbind(activeKey.keys)
 }
 
 /**

--- a/app/scripts/contentscript.js
+++ b/app/scripts/contentscript.js
@@ -146,7 +146,7 @@ chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
     return
   }
   let handled = true
-  if (request.action === "update") {
+  if (request.action === 'update') {
     Shortkeys.getShortkeys()
   } else {
     handled = false

--- a/app/scripts/options.js
+++ b/app/scripts/options.js
@@ -247,10 +247,13 @@ app.controller('ShortkeysOptionsCtrl', ['$scope', function ($scope) {
     })
     localStorage.shortkeys = JSON.stringify(settings) // @TODO: Why are we stringifying? Stop that.
 
+    // Refresh shortkey data in content scripts:
+    chrome.runtime.sendMessage({action: 'updateShortkeys'})
+    
     // Add a success messsage, an empty config if needed, and scroll up.
     $scope.alerts = [{
       type: 'success',
-      msg: 'Your settings were saved! Reload your tabs to use your new shortcuts.'
+      msg: 'Your settings were saved! You should now be able to use your new shortcuts. If you can´t then try to reload your tabs.'
     }]
     $scope.addBlankIfEmpty()
     window.scroll(0, 0)

--- a/app/scripts/options.js
+++ b/app/scripts/options.js
@@ -249,7 +249,7 @@ app.controller('ShortkeysOptionsCtrl', ['$scope', function ($scope) {
 
     // Refresh shortkey data in content scripts:
     chrome.runtime.sendMessage({action: 'updateShortkeys'})
-    
+
     // Add a success messsage, an empty config if needed, and scroll up.
     $scope.alerts = [{
       type: 'success',


### PR DESCRIPTION
When the extension is installed tabs must be reloaded before the content scripts are loaded. Also when shortkeys are changed the tabs must also be reloaded before the new information becomes available. This pull request should fix this. 

This pull request also sets content scripts to load at `document_start` which should make them apply shortkeys faster. Since the content scripts doesn't access the HTML document it shouldn't matter if it is loaded when the content script is started.