### PR TITLE
Add  "Open bookmark/bookmarklet in new background tab and close immediately after load" action

### DIFF
--- a/app/pages/options.html
+++ b/app/pages/options.html
@@ -66,7 +66,7 @@
             </div>
 
 
-            <div ng-show="key.action == 'openbookmark' || key.action == 'openbookmarknewtab' || key.action == 'openbookmarkbackgroundtab'" class="form-group">
+            <div ng-show="key.action == 'openbookmark' || key.action == 'openbookmarknewtab' || key.action == 'openbookmarkbackgroundtab' || key.action == 'openbookmarkbackgroundtabandclose'" class="form-group">
               <label>Bookmark</label>
               <select width="'100%'" ng-model="key.bookmark" ng-options="bookmark for bookmark in bookmarks track by bookmark" class="form-control">
                 <option value="">Select bookmark...</option>

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -270,7 +270,7 @@ let handleAction = (action, request = {}) => {
     chrome.tabs.executeScript(null, {'code': 'window.scrollBy(50,0)'})
   } else if (action === 'scrollrightmore') {
     chrome.tabs.executeScript(null, {'code': 'window.scrollBy(500,0)'})
-  } else if (action === 'openbookmark' || action === 'openbookmarknewtab' || action === 'openbookmarkbackgroundtab') {
+  } else if (action === 'openbookmark' || action === 'openbookmarknewtab' || action === 'openbookmarkbackgroundtab' || action === 'openbookmarkbackgroundtabandclose') {
     chrome.bookmarks.search({title: request.bookmark}, function (nodes) {
       let openNode
       for (let i = nodes.length; i-- > 0;) {
@@ -286,6 +286,16 @@ let handleAction = (action, request = {}) => {
         })
       } else if (action === 'openbookmarkbackgroundtab') {
         chrome.tabs.create({url: decodeURI(openNode.url), active: false})
+      } else if (action === 'openbookmarkbackgroundtabandclose') {
+        chrome.tabs.create({url: decodeURI(openNode.url), active: false}, (createdTab) => {
+          var closeListener = function(tabId, changeInfo, updatedTab) {
+            if (tabId == createdTab.id && changeInfo.status == "complete") {
+              chrome.tabs.remove(createdTab.id)
+              chrome.tabs.onUpdated.removeListener(closeListener)
+            }
+          };
+          chrome.tabs.onUpdated.addListener(closeListener)
+        })
       } else {
         chrome.tabs.create({url: decodeURI(openNode.url)})
       }

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -288,12 +288,12 @@ let handleAction = (action, request = {}) => {
         chrome.tabs.create({url: decodeURI(openNode.url), active: false})
       } else if (action === 'openbookmarkbackgroundtabandclose') {
         chrome.tabs.create({url: decodeURI(openNode.url), active: false}, (createdTab) => {
-          var closeListener = function(tabId, changeInfo, updatedTab) {
-            if (tabId == createdTab.id && changeInfo.status == "complete") {
+          var closeListener = function (tabId, changeInfo, updatedTab) {
+            if (tabId === createdTab.id && changeInfo.status === 'complete') {
               chrome.tabs.remove(createdTab.id)
               chrome.tabs.onUpdated.removeListener(closeListener)
             }
-          };
+          }
           chrome.tabs.onUpdated.addListener(closeListener)
         })
       } else {

--- a/app/scripts/options.js
+++ b/app/scripts/options.js
@@ -42,6 +42,7 @@ app.controller('ShortkeysOptionsCtrl', ['$scope', function ($scope) {
     {value: 'openbookmark', label: 'Open bookmark/bookmarklet in current tab', group: 'Bookmarks'},
     {value: 'openbookmarknewtab', label: 'Open bookmark/bookmarklet in new tab', group: 'Bookmarks'},
     {value: 'openbookmarkbackgroundtab', label: 'Open bookmark/bookmarklet in new background tab', group: 'Bookmarks'},
+    {value: 'openbookmarkbackgroundtabandclose', label: 'Open bookmark/bookmarklet in new background tab and close immediately after load', group: 'Bookmarks'},
     {value: 'gototab', label: 'Jump to tab by URL', group: 'Tabs'},
     {value: 'gototabbytitle', label: 'Jump to tab by title', group: 'Tabs'},
     {value: 'gototabbyindex', label: 'Jump to tab by index', group: 'Tabs'},


### PR DESCRIPTION
In my work context, I have a few script URLs that I need to call in my browser very often. I used to use the action "Open bookmark/bookmarklet in new background tab" load these URLs.

However, I don't need the output of these scripts, the purpose of calling them is just to perform some action on the server side. So in order to no being overwhelmed by obsolete tabs, they should be closed immediately when loading has finished.

For this purpose I have implemented the action "Open bookmark/bookmarklet in new background tab and close immediately after load". Please let me know what you think about it.