### PR TITLE
add babel-plugin-transform-runtime to dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "babel-cli": "6.x.x",
     "babel-core": "6.x.x",
     "babel-loader": "7.x.x",
+    "babel-plugin-transform-runtime": "^6.23.0",
     "babel-preset-env": "^1.6.1",
     "chai": "4.x.x",
     "chromereload": "0.x.x",


### PR DESCRIPTION
nitpick, but `npm install` after a fresh clone of the repo will remove this module from the `package.json.lock`, so I added it to the dev dependencies list.
