### PR TITLE
Add deleting all shortcuts button

### DIFF
--- a/app/pages/options.html
+++ b/app/pages/options.html
@@ -164,7 +164,11 @@
 
     <!-- IMPORT TAB -->
     <uib-tab index="1" heading="Import"><br />
-      <p>Paste in JSON exported from Shortkeys to import it here.</p>
+      <div style="display: flex; justify-content: space-between";>
+        <p>Paste in JSON exported from Shortkeys to import it here.</p>
+        <a ng-click="deleteAllKeys()" class="delete-all">Delete all shortcuts</a>
+      </div>
+
       <form>
         <div class="form-group">
           <label>Import</label>

--- a/app/scripts/options.js
+++ b/app/scripts/options.js
@@ -183,6 +183,13 @@ app.controller('ShortkeysOptionsCtrl', ['$scope', function ($scope) {
   }
 
   /**
+   * Delete all shortcuts. Used by the "Delete all shortcuts" button/link.
+   */
+  $scope.deleteAllKeys = function () {
+    chrome.extension.getBackgroundPage().confirm('Are you sure you want to delete all?') && $scope.keys.splice(0, $scope.keys.length)
+  }
+
+  /**
    * Export stringified JSON for a key or set of keys.
    *
    * @param index

--- a/app/styles/options.scss
+++ b/app/styles/options.scss
@@ -24,6 +24,15 @@ body {
   }
 }
 
+a.delete-all {
+  color: #d9534f;
+  text-decoration: none;
+}
+a.delete-all:hover {
+  color: #d9534f;
+  text-decoration: underline;
+}
+
 .CodeMirror-wrap {
   border: 1px solid #d0d0d0 !important;
   padding: 5px !important;


### PR DESCRIPTION
I add deleting all shortcuts button.

# Reason

Importing JSON is useful, but the deleting all shortcuts requires long steps.

If the deleting all shortcuts is enabled by 1 click, we can manage the source JSON file at any places.
For example, I place the JSON file at dotfiles, edit it, and import it at the option page.

# Step

1. Open "Import" tab.
2. Click "Delete all shotcuts" button.
3. Confirm the clicking.
4. All shortcuts will be deleted.

# Image

![image](https://user-images.githubusercontent.com/5919569/57902401-f102b680-78a3-11e9-8de8-d8a54b6d2e17.png)

![image](https://user-images.githubusercontent.com/5919569/57902411-fbbd4b80-78a3-11e9-9775-292671334f37.png)

**※ Notice**
My Chrome's launguage settings is Japanese.
The bellows image shows 2 buttons meaning "Cancel" and "OK".
