### PR TITLE
next/previous tab: don't jump to hidden tabs

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -14,19 +14,37 @@ let copyToClipboard = (text) => {
 }
 
 let selectTab = (direction) => {
-  browser.tabs.query({currentWindow: true}).then(function(tabs) {
+  // default search parameters for most browsers
+  let searchParameter = {currentWindow: true};
+  if (typeof browser.runtime.getBrowserInfo === "function") {
+    browser.runtime.getBrowserInfo().then(function(browserInfo) {
+      // currently getBrowserInfo() is only supproted by firefox. But we check for the browser anyway
+      // to be future-compatible :-).
+      if (browserInfo.name == 'Firefox') {
+        searchParameter = {currentWindow: true, hidden:false};
+      }
+      selectTabSub(direction, searchParameter);
+    });
+  } else {
+      selectTabSub(direction, searchParameter);
+  }
+}
+
+let selectTabSub = (direction, searchParameter) => {
+  browser.tabs.query(searchParameter).then(function(tabs) {
     if (tabs.length <= 1) {
       return
     }
     browser.tabs.query({currentWindow: true, active: true}).then(function(currentTabInArray) {
       let currentTab = currentTabInArray[0]
+      let currentTabIndex = tabs.findIndex(i => i.id === currentTab.id);
       let toSelect
       switch (direction) {
         case 'next':
-          toSelect = tabs[(currentTab.index + 1 + tabs.length) % tabs.length]
+          toSelect = tabs[(currentTabIndex + 1 + tabs.length) % tabs.length]
           break
         case 'previous':
-          toSelect = tabs[(currentTab.index - 1 + tabs.length) % tabs.length]
+          toSelect = tabs[(currentTabIndex - 1 + tabs.length) % tabs.length]
           break
         case 'first':
           toSelect = tabs[0]


### PR DESCRIPTION
I avoid javascript whenever possible, so I guess it's not the most beautiful solution. Specially those promises drove me nuts. I wanted to use async/wait, but then other parts of the code didn't work anymore, and I didn't want to change too much of your code. So that's how I implemented it at the end.
I've tested it in firefox and in chrome.
