### PR TITLE
Fallback to default value, if localStorage.shortkeys not found

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -379,7 +379,7 @@ browser.runtime.onMessage.addListener(function (request, sender, sendResponse) {
   const action = request.action
   if (action === 'getKeys') {
     const currentUrl = request.url
-    let settings = JSON.parse(localStorage.shortkeys)
+    let settings = localStorage.shortkeys ? JSON.parse(localStorage.shortkeys) : [{}]
     let keys = []
     if (settings.keys.length > 0) {
       settings.keys.forEach((key) => {


### PR DESCRIPTION
Fixes #424

Note: Loading `app/manifest.json` in `about:debugging` doesn't throw the error, but loading `dist/firefox/manifest.json` does.